### PR TITLE
revise #20 ONNX 推論を CUDA EP で実行可能にする + 開発者ドキュメント整備

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,8 +7,12 @@
       "Bash(docker restart *)",
       "Bash(openssl genrsa *)",
       "Bash(openssl req *)",
+      "Bash(npm run *)",
+      "Bash(curl -sk https://localhost:8443/api/sessions -X POST)",
+      "Bash(curl -sk https://localhost:8443/api/health)",
+      "Bash(curl -s http://localhost:3001/api/health)",
+      "Bash(curl -s -X POST http://localhost:3001/api/sessions)"
     ],
-    "additionalDirectories": [
-    ]
+    "additionalDirectories": []
   }
 }

--- a/README.md
+++ b/README.md
@@ -75,4 +75,5 @@ iPhone Safari (推奨) または Android Chrome で実機テストする手順�
 ## 関連ドキュメント
 
 - アーキテクチャ詳細: [`docs/architecture.md`](docs/architecture.md)
-- 開発環境の立て直しメモ: [`docs/開発環境の立て直し.md`](docs/開発環境の立て直し.md)
+- 開発環境ガイド: [`docs/development.md`](docs/development.md)
+- フォルダ構成: [`docs/structure.md`](docs/structure.md)

--- a/backend/services/depth/estimator.onnx.ts
+++ b/backend/services/depth/estimator.onnx.ts
@@ -107,9 +107,33 @@ async function ensureModelAndCreateSession(): Promise<ort.InferenceSession> {
   }
 
   console.log(`[depth] ONNX セッションを作成中: ${modelPath}`)
-  const session = await ort.InferenceSession.create(modelPath)
+  const session = await createSessionWithFallback(modelPath)
   console.log('[depth] ONNX セッション作成完了')
   return session
+}
+
+// ONNX_EXECUTION_PROVIDER で EP を切替える。
+//   - 'cuda': CUDA のみ。失敗したら例外。
+//   - 'cpu' : CPU のみ。
+//   - 'auto' (デフォルト): CUDA → CPU の順に試し、最初に成功したものを使う。
+async function createSessionWithFallback(modelPath: string): Promise<ort.InferenceSession> {
+  const mode = (process.env.ONNX_EXECUTION_PROVIDER ?? 'auto').toLowerCase()
+  const providers = mode === 'cpu' ? ['cpu'] : mode === 'cuda' ? ['cuda'] : ['cuda', 'cpu']
+
+  let lastError: unknown
+  for (const ep of providers) {
+    try {
+      const session = await ort.InferenceSession.create(modelPath, {
+        executionProviders: [ep as ort.InferenceSession.ExecutionProviderConfig],
+      })
+      console.log(`[depth] EP=${ep} で ONNX セッションを作成しました`)
+      return session
+    } catch (err) {
+      lastError = err
+      console.warn(`[depth] EP=${ep} のセッション作成に失敗:`, err instanceof Error ? err.message : err)
+    }
+  }
+  throw lastError ?? new Error('利用可能な ONNX Execution Provider がありません')
 }
 
 // テスト用にキャッシュをリセット

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,8 @@ services:
       - SESSION_STORE=redis
       # 深度推定の選択: 'onnx' (デフォルト、Depth Anything V2 small) | 'mock' (常に固定深度)
       - DEPTH_ESTIMATOR=onnx
+      # ONNX Execution Provider の選択: 'auto' (CUDA→CPU フォールバック) | 'cuda' | 'cpu'
+      - ONNX_EXECUTION_PROVIDER=auto
     volumes:
       - ./backend:/app
       - backend_node_modules:/app/node_modules
@@ -53,6 +55,17 @@ services:
     command: sh -c 'npm install && npm run dev'
     ports:
       - "3001:3000"
+    # GPU を全て割り当て (docker run --gpus all 相当)。
+    # 前提: ホストに NVIDIA ドライバ + NVIDIA Container Toolkit が入っていること。
+    # backend イメージ側にも CUDA ランタイムが必要 (現状の node:20-slim では CUDA 非対応のため
+    # CUDA EP は無効化される。CUDA 利用時は Dockerfile を nvidia/cuda ベースへ切替)。
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
     depends_on:
       redis:
         condition: service_started

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,8 +1,20 @@
-FROM node:20-slim
+FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04
 
-# onnxruntime-node や sharp など glibc 前提のネイティブモジュールが動くよう
-# Debian 系の slim イメージを使う。Alpine (musl libc) では onnxruntime-node が
-# ld-linux-x86-64.so.2 を要求して起動失敗するため。
+# CUDA + cuDNN ランタイム同梱イメージ。onnxruntime-node の CUDA EP 利用に必要。
+# CUDA 非対応のホストでも、コンテナ自体はそのまま起動して CPU EP でフォールバックする。
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    TZ=Asia/Tokyo \
+    NODE_VERSION=20
+
+# Node.js 20 と sharp / onnxruntime のネイティブビルドに必要なツールを導入。
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl gnupg \
+        python3 make g++ \
+    && curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -173,7 +173,3 @@ Content-Type: multipart/form-data
 - 撮影画像はセッション内 (`/tmp/madori/<sessionId>/`) に一時保存し、セッション終了時に破棄
 - セッション ID は UUID v4 で推測困難
 - カメラ・モーション利用は iOS のユーザー許可フローに従う
-
----
-
-最終更新: 2026-04-29

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,174 @@
+---
+title: 開発環境ガイド
+---
+
+# 開発環境ガイド
+
+本プロジェクトは Docker Compose で完結する開発環境を提供する。フロント/バックエンド/プロキシ/DB/Redis を一括で起動し、ホスト側からは HTTPS の単一ポート (8443) で動作確認できる。
+
+関連ドキュメント:
+- アーキテクチャ詳細: [architecture.md](architecture.md)
+- フォルダ構成: [structure.md](structure.md)
+
+## 前提
+
+- Docker Engine / Docker Compose v2 (`docker compose` サブコマンド形式)
+- Node.js は不要 (コンテナ内で実行)。ホストでテストや型チェックだけ行いたい場合は Node.js 20.x を使う
+- Linux / macOS / Windows + WSL2 で動作確認 (本リポジトリは WSL2 上で開発)
+- iPhone 実機テストには PC と iPhone を同一 LAN に置き、PC のローカル IP を控える
+
+### 開発機の参考スペック
+
+- メモリ 6GB (frontend / backend / nginx / redis / db を全部走らせると逼迫気味)
+- **CUDA 利用可能**。NVIDIA Container Toolkit が入っていれば `docker run --gpus all` / Compose の `deploy.resources.reservations.devices` で GPU をコンテナへ渡せる
+- backend イメージは `nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04` ベース。`docker-compose.yml` の `backend.deploy.resources.reservations.devices` で GPU を全て予約済み
+- `ONNX_EXECUTION_PROVIDER=auto` (デフォルト) は CUDA → CPU の順に試行する。CUDA が使えない環境でも CPU EP で起動できる
+
+### GPU 推論の動作確認
+
+```bash
+# ホスト側で NVIDIA Container Toolkit が動いているか
+docker run --rm --gpus all nvidia/cuda:12.4.1-base-ubuntu22.04 nvidia-smi
+
+# backend コンテナ内で GPU が見えるか
+docker compose exec backend nvidia-smi
+
+# 起動ログで EP=cuda が選ばれているか
+docker compose logs backend | grep -E "depth|EP="
+```
+
+CUDA を使いたくない環境では `ONNX_EXECUTION_PROVIDER=cpu` にして再起動する。
+
+## サービス構成
+
+`docker-compose.yml` で以下 5 サービスを起動する。
+
+| サービス | コンテナ名 | ホスト公開ポート | 役割 |
+|---------|-----------|----------------|------|
+| `nginx` | `madori-nginx` | `8443` (HTTPS) | TLS 終端 + フロント/API のリバースプロキシ |
+| `frontend` | `madori-frontend` | `3000` | Vite dev server (React + PWA) |
+| `backend` | `madori-backend` | `3001` | Express API + ONNX 深度推定 |
+| `db` | `madori-db` | `3306` | MySQL 8 (将来用、現在未使用) |
+| `redis` | `madori-redis` | `6379` | セッションストア (`SESSION_STORE=redis`) |
+
+ボリューム:
+
+| ボリューム | 用途 |
+|-----------|------|
+| `frontend_node_modules` | フロントの `node_modules` をコンテナ内で永続化 |
+| `backend_node_modules` | バックエンドの `node_modules` を永続化 |
+| `backend_models` | ONNX モデル (`Depth Anything V2 small`) を永続化 (初回起動時にダウンロード) |
+| `mysql_data` | MySQL のデータディレクトリ |
+
+## 主要環境変数
+
+`backend` サービスで利用する環境変数 (`docker-compose.yml` で定義済み):
+
+| 変数 | デフォルト | 意味 |
+|------|-----------|------|
+| `PORT` | `3000` | バックエンドの listen ポート (コンテナ内) |
+| `DATABASE_URL` | `mysql://root:password@db:3306/madori` | MySQL 接続先 (現状未使用) |
+| `REDIS_URL` | `redis://redis:6379` | Redis 接続先 |
+| `SESSION_STORE` | `redis` | `redis` で永続化、それ以外で in-memory にフォールバック |
+| `DEPTH_ESTIMATOR` | `onnx` | `onnx` で Depth Anything V2 small、`mock` で固定深度モック |
+| `ONNX_EXECUTION_PROVIDER` | `auto` | `auto` (CUDA→CPU フォールバック) / `cuda` / `cpu` |
+
+## 起動と停止
+
+```bash
+# 起動 (バックグラウンド)
+docker compose up -d
+
+# ログ確認
+docker compose logs -f backend
+docker compose logs -f frontend
+
+# 停止
+docker compose down
+
+# ボリュームごと破棄 (モデル/DB/Redis のキャッシュもクリア)
+docker compose down -v
+```
+
+ブラウザで `https://localhost:8443/` (LAN テスト時は `https://<host-ip>:8443/`) を開く。自己署名証明書のため、初回は警告ページから訪問を許可する必要がある。
+
+## 自己署名 SSL 証明書
+
+`docker/nginx/certs/server.crt` と `server.key` をマウントして利用する。リポジトリには既に同梱済み (CN=localhost, 365 日)。再生成したい場合は `docker/nginx/generate-certs.sh` を参考に再作成する。
+
+注意: スクリプト先頭の `cd /home/user/works/madori-creator/nginx` はパスが固定されているため、自身の環境に合わせて修正してから実行する。
+
+## nginx ルーティング
+
+`docker/nginx/nginx.conf` で以下のように振り分けている。
+
+| パス | プロキシ先 | 備考 |
+|------|-----------|------|
+| `/api/` | `backend:3000` | prefix を維持して `/api/...` を転送 |
+| `/__vite_ws` | `frontend:3000` | Vite HMR の WebSocket (Upgrade) |
+| `/` | `frontend:3000` | Vite dev server |
+
+`client_max_body_size 20M` でフレーム画像のアップロードを許容。タイムアウトは 120 秒。
+
+## フロント (Vite) 設定
+
+[front/vite.config.ts](../front/vite.config.ts):
+
+- `host: 0.0.0.0`, `port: 3000`
+- HMR は `wss://<host>:8443/__vite_ws` で接続 (nginx 経由)
+- `proxy: '/api' → http://backend:3000` (Docker ネットワーク内)
+- `vite-plugin-pwa` で PWA マニフェスト/SW を生成。dev 時は `devOptions.enabled: false` (キャッシュ起因の真っ白画面回避)
+
+## バックエンド初期化フロー
+
+[backend/index.ts](../backend/index.ts):
+
+1. `express` を生成、`/health` と `/api` ルータを登録
+2. `initSessionStore()` で `SESSION_STORE=redis` のとき `REDIS_URL` に接続。失敗時は in-memory にフォールバック
+3. `0.0.0.0:${PORT}` で listen
+
+ONNX 深度推定は初回フレーム到着時にモデルを `/app/models` (`backend_models` ボリューム) にダウンロードする。失敗時はプロセス全体ではなくモック (`estimator.mock.ts`) にフォールバックして撮影パイプラインを継続する。
+
+## ホストでのテスト/型チェック
+
+コンテナを介さず、ホストの Node.js 20.x で実行可能。
+
+```bash
+# バックエンド
+cd backend
+npm install
+npm run type-check    # tsc --noEmit
+npm run test          # vitest run
+
+# フロント
+cd front
+npm install
+npm run type-check
+npm run test
+npm run lint
+```
+
+`backend/_legacy/` は `tsconfig.json` の `exclude` に入っており型チェック対象外 (詳細は [structure.md](structure.md) 参照)。
+
+## トラブルシュート
+
+| 症状 | 対処 |
+|------|------|
+| iPhone でカメラ/モーション許可ダイアログが出ない | HTTP でアクセスしている可能性。`https://` で開く。Safari は許可状態を `設定 > Safari > Web サイト` で確認 |
+| HMR が効かない/真っ白 | dev 時の Service Worker が古い asset を返している。ブラウザの `Application > Service Workers` で Unregister |
+| `onnxruntime-node` が起動しない | Alpine (musl) は不可。backend は `nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04` (glibc) を使用 |
+| GPU を渡したのに CPU で動く | コンテナ内 `nvidia-smi` が動かない場合はホストの NVIDIA Container Toolkit を確認。動くのに CPU が選ばれる場合は cuDNN バージョン不整合の可能性 (`docker compose logs backend` で `EP=cuda のセッション作成に失敗` を確認) |
+| Redis 接続失敗ログ | コンテナ起動順や Redis 障害時。in-memory にフォールバックして動作継続するためログのみ。永続化が必要なら復旧後に `docker compose restart backend` |
+| 画像アップロードで 413 | nginx の `client_max_body_size` が 20MB。JPEG が極端に大きい場合は前処理側でリサイズしてから送信する |
+
+## 実機テスト手順
+
+1. PC で `docker compose up -d`
+2. 同一 LAN の iPhone Safari で `https://<PC の LAN IP>:8443/` を開く
+3. 自己署名証明書の警告から訪問を許可
+4. 中央下の白い丸ボタン (開始) をタップ
+5. DeviceMotion / カメラ許可ダイアログを「許可」
+6. ステータスが「撮影中」になったら、ゆっくり部屋を歩きながらかざす
+7. 部屋を一周したらもう一度ボタンをタップして停止
+
+詳細な期待挙動と既知の制約は [README.md](../README.md) を参照。

--- a/docs/issue-6-followups.md
+++ b/docs/issue-6-followups.md
@@ -1,0 +1,128 @@
+---
+title: issue #6 残課題まとめ
+---
+
+# issue #6 サーバー処理実装 (Phase 2) の残課題
+
+[issue #6](https://github.com/loopsketch/madori-creator/issues/6) と派生 sub-issue (#9〜#18) は [PR #19](https://github.com/loopsketch/madori-creator/pull/19) で一通りマージされ closed になったが、運用・実機テスト・将来 Phase に持ち越した項目が複数ある。本ドキュメントは「issue #6 系列のあと、何が残っているか」を一望するためのもの。
+
+関連: [architecture.md](architecture.md) / [development.md](development.md) / [structure.md](structure.md)
+
+## sub-issue 進捗サマリ
+
+| # | タイトル | 状態 | 備考 |
+|---|---------|------|------|
+| #9 | 画像受信・検証パイプライン | closed | multer + Sharp + validator 完了 |
+| #10 | COLMAP Docker 連携 | closed (未実装) | real-time 方針への切替で取りやめ |
+| #11 | OpenMVS Docker 連携 | closed (未実装) | 同上 |
+| #12 | 床面・壁線抽出 (RANSAC) | closed | 軽量実装で完了。品質は要改善 (後述) |
+| #13 | SVG/DXF 出力整備 | closed | 上面ビュー SVG + AutoCAD R12 DXF 実装。CAD 互換性検証は未完 |
+| #14 | セッションストアの Redis 永続化 | closed | Repository 抽象 + Redis 実装。再起動跨ぎ動作検証は未完了 |
+| #15 | セッション API 設計と実装 | closed | POST/GET/DELETE /api/sessions, POST .../frames |
+| #16 | 単眼深度推定 (ONNX) | closed | Depth Anything V2 small。性能目標は未達 |
+| #17 | DeviceMotion + 疑似スケール | closed | 重力で世界座標確定、持ち手 150cm 仮定 |
+| #18 | フロント撮影ストリーミング UI | closed | レスポンス駆動ループで SVG 逐次反映 |
+| #20 | ONNX 推論の GPU (CUDA) 化 | open | Phase 3 へ向けた性能改善 (開発機 CUDA 利用可) |
+
+## 1. PR #19 の Test plan で未確認のままの項目
+
+PR #19 のテスト計画で `- [ ]` のまま残っている項目。実装はあるが運用検証だけが未完。
+
+- [ ] `docker compose restart backend` してもセッションが残ること (Redis 永続化の確認)
+- [ ] `curl -X POST -F frame=@...jpg` でフレームを送ると JSON レスポンスに SVG が含まれること
+- [ ] `DELETE` で `finalSvg` と `finalDxf` が返り、Redis から key が削除されること
+
+### 推奨アクション
+- E2E 用の小さな bash スクリプト (`scripts/e2e-session.sh` 程度) を追加し、CI でも回せる形にする
+- Redis 永続化の検証は `docker compose restart backend` 前後で `GET /api/sessions/:id` の `totalFrames` が維持されることを確認
+
+## 2. 各 sub-issue の完了条件で未チェックのままの項目
+
+issue 本文のチェックボックスは PR で機械的にチェックされなかったものが多い。実装済み = 動作確認も済んでいる、とは限らない点に注意。
+
+### #12 床面・壁線抽出
+- [ ] サンプル点群から平面 (床) を1つ以上抽出できる ← 単体テストでは確認、実フレームで検証は別件
+- [ ] 床と直交する壁線が抽出できる
+- 既知の課題: フレームごとに RANSAC を独立実行しているため、検出される壁線が安定せず**フレーム間で増減する**
+
+### #13 SVG/DXF 出力
+- [ ] SVG がブラウザで描画される (frontend MapView で表示はしているが、サイズ・スケールバー等は未整備)
+- [ ] **DXF が LibreCAD で開ける** ← 互換性の実機検証が未完。AutoCAD R12 DXF として書き出しているが要確認
+- viewBox とスケール (1m=1unit, Y 反転) は揃っているが、レイヤー化 (壁・床・天井の `<g>`) は単純化されている
+
+### #16 単眼深度推定
+- **1フレームの推論時間 <500ms 目標**: issue #20 で GPU 化対応中
+  - backend イメージを `nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04` へ切替済 (#20)
+  - `docker-compose.yml` に GPU 予約追加済 (#20)
+  - `ONNX_EXECUTION_PROVIDER` 環境変数 (auto / cuda / cpu) 追加済 (#20)
+  - 実機での推論時間計測は #20 内で実施
+  - GPU 化でも目標未達なら、より軽量なモデル (MiDaS small 等) への切替を再検討
+- カメラ intrinsics は機種推定をやめ「横画角 77° の固定値」になっているため、機種判別の余地あり
+
+### #17 DeviceMotion + 疑似スケール
+- 設定 UI (校正画面) は将来スコープとして据え置き。現状はコードに固定値 `HAND_HELD_HEIGHT_M = 1.5m`
+
+## 3. issue #6 で「後回し」と明記された項目
+
+issue #6 のコメント (作業変更) で意図的にスコープ外にした事項。
+
+- **データのエクスポート処理は後回し**: SVG/DXF の最低限は #13 で実装したが、レイヤー構造の完全表現や CAD 互換テストは Phase 3 へ
+- **鳥観図を重ね合わせ表示**: 撮影中に間取り図を鳥瞰図として重ねて表示する UI。階層判断 (1F/2F 等) も含めて未着手
+- **単体テスト**: backend 53 件 / frontend 2 件で完了済み。frontend 側のカバレッジ拡充は継続課題
+
+## 4. PR #19 の「既知の制約」として明示された将来課題
+
+撮影 → 間取り図のパイプラインは通ったが、**「使える間取り図」品質には未到達**。本格的に役立てるには次フェーズで以下に取り組む必要がある。
+
+| 項目 | 内容 | 想定アプローチ |
+|------|------|--------------|
+| 絶対スケールが出ない | 単眼カメラ原理上の制約 | ユーザー校正 UI (最初の壁長入力)、AR 系 API (WebXR) 併用、両眼/ToF 端末対応 |
+| 壁線が増減して安定しない | フレームごと独立 RANSAC | 壁線の時系列クラスタリング、信頼度ベースのマージ、Kalman フィルタ |
+| 姿勢が初期固定 | worldOrientation が初期値で固定。撮影中に向きを変えると点群が歪む | 簡易 Visual-Inertial 推定、DeviceMotion の継続積分、本格 SLAM (ORB-SLAM3 等) |
+| 階層 (1F/2F 等) 認識なし | 鳥瞰図の重ね合わせ表示の前提 | 重力方向の累積位置から床高さクラスタリング |
+
+これらは **Phase 3 (issue #7)** や新規 issue 群で取り扱う想定。issue #7 は現在 OPEN だが Phase 3 のスコープ整理は未着手。
+
+## 5. backend/_legacy/ の扱い
+
+`backend/_legacy/` は issue #6-1 で退避した旧コード。real-time 方針への切替で **#10/#11 (COLMAP/OpenMVS) は復活予定なし**。残るファイルの状況:
+
+| _legacy ファイル | 当初の復活予定 | 現状 |
+|------------------|--------------|------|
+| `api/reconstruction.ts` | #6-2 | #9 で新規実装済 (コードは資料扱い) |
+| `services/reconstruction.ts` | #12 | #12 でリライト済 |
+| `services/export.ts` | #13 | #13 でリライト済 |
+| `services/cache/*` | #14 | #14 のスコープ変更 (Redis 永続化に集約) で**未復活** |
+| `services/validators/imageValidator.ts` | #9 | #9 で新規実装 |
+| `docker/{colmap,openmvs}.ts` | #10/#11 | **復活予定なし** (close) |
+| `errors/reconstruction.ts` | 各 sub-issue | 一部のみ復活 (`InputValidationError` / `ImageProcessingError`) |
+| `utils/queue.ts` | #14 | **復活予定なし** (レスポンス駆動と相性が悪い) |
+| `types/task.ts` | 統合 | `types/index.ts` に統合済 |
+
+### 推奨アクション
+- `_legacy/` は資料としての価値が薄れている。Phase 3 着手時に削除するか、`docs/legacy-reference.md` に要点だけ抽出して退避する判断を行う
+
+## 6. インフラ・運用面の積み残し
+
+PR #19 では触れていないが、運用に乗せる前に必要になる項目。
+
+- **本番ビルド経路の未整備**: `Dockerfile` は `npm run dev` を CMD にしている。`vite build` + `vite preview` or 静的配信、backend は `tsc` ビルド成果物の `node` 起動への切替が必要
+- **CI 未整備**: GitHub Actions 等で `type-check` + `vitest` を回す設定なし
+- **MySQL 未使用**: `docker-compose.yml` に `db` がいるが backend からは未接続。セッション履歴の長期保存が必要なら設計から
+- **証明書管理**: 自己署名のまま。LAN 開発はこれで OK だが、本番想定なら Let's Encrypt or 別経路
+- **モデル DL 失敗時のリトライ**: 現状は ONNX 失敗時にモック深度へ恒久フォールバック。ネットワーク復旧後の再試行ポリシーなし
+- **ログ整備**: `console.log` ベース。構造化ログ (pino 等) と外部送出は未整備
+
+## 7. 次に着手するなら何から
+
+依存と効果を考慮した推奨順 (あくまで提案):
+
+1. **Test plan の未確認 3 項目** を E2E スクリプトで自動化 (1 日)
+2. **ONNX 推論の GPU 化** (issue #20、対応中): CUDA EP + `--gpus all` で <500ms 目標 (2〜3 日)
+3. **DXF の CAD 互換性検証** (LibreCAD で実物を開く) → 不備があれば書き出しを修正 (1〜2 日)
+4. **撮影中の姿勢追従**: 重力ベクトルを毎フレーム更新して点群歪みを軽減 (#17 の延長、3〜5 日)
+5. **壁線の時系列マージ**: フレーム間でクラスタリングし安定化 (#12 の延長、5〜7 日)
+6. **校正 UI**: 「最初の壁の長さ」入力でスケール補正 (#17 の将来分、3 日)
+7. **本番ビルド経路と CI** (1〜2 日)
+
+4〜6 は Phase 3 (issue #7) のスコープを再定義する形で issue を切り直すのが筋。

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,0 +1,144 @@
+---
+title: フォルダ構成
+---
+
+# フォルダ構成
+
+リポジトリのトップレベルとサブディレクトリの役割をまとめる。実装の詳細は [architecture.md](architecture.md)、起動方法は [development.md](development.md) を参照。
+
+## トップレベル
+
+```
+madori-creator/
+├── README.md              プロジェクト概要・実機テスト手順
+├── CLAUDE.md              プロジェクト固有の運用ガイドライン
+├── docker-compose.yml     開発環境一式 (frontend / backend / nginx / db / redis)
+├── docs/                  設計・運用ドキュメント
+├── docker/                各サービスの Dockerfile / 設定ファイル
+├── front/                 フロントエンド (React + Vite + PWA)
+├── backend/               バックエンド (Express + ONNX Runtime)
+└── res/                   実機テスト用のリソース置き場 (画像など、現在は空)
+```
+
+## docs/
+
+| ファイル | 内容 |
+|---------|------|
+| [architecture.md](architecture.md) | システム全体の設計、撮影フロー、処理パイプライン、API 設計 |
+| [development.md](development.md) | 開発環境の起動・停止、環境変数、テスト、トラブルシュート |
+| [structure.md](structure.md) | (本ファイル) フォルダ構成 |
+| [issue-6-followups.md](issue-6-followups.md) | issue #6 系列の残課題 (実機検証・将来 Phase へ持ち越した項目) |
+
+## docker/
+
+各サービスの Dockerfile と設定。Compose の `build.context` は各アプリディレクトリを指し、Dockerfile はこちらから参照する構成。
+
+```
+docker/
+├── backend/Dockerfile     node:20-slim ベース (onnxruntime-node が glibc を要求するため)
+├── front/Dockerfile       node:20-alpine ベース
+└── nginx/
+    ├── nginx.conf         /api → backend:3000、/__vite_ws → frontend:3000、/ → frontend:3000
+    ├── generate-certs.sh  自己署名証明書生成スクリプト
+    └── certs/             server.crt / server.key (CN=localhost, 同梱)
+```
+
+## front/
+
+```
+front/
+├── index.html             SPA エントリ
+├── main.tsx               React マウント
+├── App.tsx                撮影ループ + UI 全体 (レスポンス駆動でフレーム送信)
+├── index.css              グローバル CSS
+├── vite.config.ts         Vite + PWA + HMR over wss + /api プロキシ設定
+├── tsconfig.json
+├── vitest.config.ts
+├── package.json
+├── components/            UI コンポーネント
+│   ├── CameraView.tsx       getUserMedia とフレームキャプチャ
+│   ├── CanvasDrawing.tsx    画面上の手書きレイヤ (補助)
+│   ├── MapView.tsx          受信した SVG を表示
+│   ├── BirdEyeView.tsx      上面ビュー (補助)
+│   └── index.ts             バレル
+├── lib/                   API クライアント・センサ
+│   ├── client.ts            /api 呼び出しラッパ (createSession / postFrame / closeSession)
+│   ├── motion.ts            DeviceMotion / DeviceOrientation の許可と取得
+│   └── types.ts             API レスポンス型
+├── utils/
+│   └── storage.ts           localStorage ヘルパ
+├── types/index.ts         共通型 (Point など)
+└── tests/                 vitest テスト
+```
+
+## backend/
+
+```
+backend/
+├── index.ts               Express 起動とセッションストア初期化
+├── package.json
+├── tsconfig.json          _legacy を exclude
+├── vitest.config.ts
+├── api/                   ルーティング層
+│   ├── index.ts             /api ルータ集約
+│   ├── sessions.ts          POST/GET/DELETE /api/sessions と POST /:id/frames
+│   └── reconstruction.ts    POST /api/reconstruction (バッチ画像受信)
+├── services/              ドメインロジック
+│   ├── sessions/            セッション永続化と撮影パイプライン本体
+│   │   ├── store.ts           appendFrame で深度→点群→平面検出→SVG を進める
+│   │   ├── repository.ts      抽象 (in-memory / Redis 切替インタフェース)
+│   │   ├── memory-repository.ts
+│   │   └── redis-repository.ts
+│   ├── images/              画像受信とバリデーション
+│   │   ├── validator.ts       multer の前段で形式・サイズを検査
+│   │   └── processor.ts       Sharp で EXIF 補正・リサイズ・JPEG 統一
+│   ├── depth/               単眼深度推定
+│   │   ├── estimator.ts       ONNX/モックの切替 + フォールバック
+│   │   ├── estimator.onnx.ts  Depth Anything V2 small (onnxruntime-node)
+│   │   ├── estimator.mock.ts  常に固定深度を返す
+│   │   ├── intrinsics.ts      カメラ内部パラメータ (デフォルト横画角 77°)
+│   │   ├── pointcloud.ts      深度マップ → カメラ座標 → 世界座標
+│   │   └── voxel.ts           voxel ダウンサンプル
+│   ├── scale/
+│   │   └── calibrator.ts      重力ベクトルから世界座標系を確定、持ち手 150cm 仮定
+│   ├── reconstruction/      平面検出と壁線抽出
+│   │   ├── ransac.ts          RANSAC 平面検出 (軽量実装)
+│   │   ├── floor.ts           床面 (法線が重力方向の最大平面) 抽出
+│   │   ├── walls.ts           床に直交する平面 → 2D ポリライン化
+│   │   ├── types.ts           Floor / Wall / Plane / Vec3 / Point3D
+│   │   └── index.ts           detectFloorAndWalls エクスポート
+│   ├── render/              出力フォーマット生成
+│   │   ├── svg.ts             上面ビュー SVG
+│   │   ├── dxf.ts             DXF (CAD 取り込み用)
+│   │   └── index.ts
+│   └── tasks/
+│       └── store.ts           reconstruction バッチ用のタスクメタ管理 (in-memory)
+├── errors/
+│   └── reconstruction.ts    InputValidationError / ImageProcessingError
+├── types/index.ts         API/サービス層共通型 (SessionState / FrameRecord / DepthMap など)
+├── tests/                 vitest テスト (api / depth / processor / reconstruction / render / sessions / validator / calibrator)
+├── models/                ONNX モデル置き場 (実体は backend_models ボリューム)
+└── _legacy/               旧 issue #6 実装の退避先 (型チェック対象外)
+```
+
+## backend/_legacy/
+
+issue #6 の初期実装を退避したディレクトリ。現エントリポイントから参照されず、`tsconfig.json` の `exclude` で型チェックも外している。後続 issue で再構築する際の「資料」として保持。詳細は [backend/_legacy/README.md](../backend/_legacy/README.md) 参照。
+
+`api/`, `services/`, `docker/`, `errors/`, `types/`, `utils/`, `tests/` の旧構造が原型のまま残っているが、リライト推奨と注記されている。
+
+## データの流れと配置
+
+| データ | 場所 | ライフサイクル |
+|-------|------|--------------|
+| 撮影フレーム JPEG | コンテナ内 `/tmp/madori/<sessionId>/frame-NNNN/` | セッション終了 (`DELETE`) で破棄 |
+| ONNX モデル | コンテナ内 `/app/models/` (= `backend_models` ボリューム) | 初回 DL 後は永続化 |
+| セッション状態 | Redis (`SESSION_STORE=redis`) または プロセスメモリ | プロセス再起動で in-memory は消える |
+| MySQL データ | `mysql_data` ボリューム | 現状未使用 |
+
+## 命名規約
+
+- ファイル/ディレクトリ名は kebab-case または lowercase
+- React コンポーネントファイルのみ PascalCase (`CameraView.tsx`)
+- バックエンドの service モジュールは「機能ごとのフォルダ + 小さなファイル」を基本にする (例: `services/depth/{estimator,onnx,mock,voxel}.ts`)
+- テストは各ロジックと同じディレクトリ階層には置かず、`backend/tests/` / `front/tests/` に集約


### PR DESCRIPTION
Closes #20

## 概要

issue #20 への対応として、深度推定 (Depth Anything V2 small / ONNX Runtime) を **CUDA Execution Provider** で実行できるようにした。あわせて、issue #6 系列が一段落した時点での開発者向けドキュメント (開発環境 / フォルダ構成 / 残課題) を整備。

## 変更内容

### 1. ONNX 推論の GPU (CUDA) 化 (#20)

| ファイル | 変更 |
|---------|------|
| docker/backend/Dockerfile | ベースを node:20-slim から nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04 へ。Node.js 20 を NodeSource から導入し、sharp / onnxruntime のネイティブビルドに必要な python3 / make / g++ を追加 |
| docker-compose.yml | backend に GPU 予約 (deploy.resources.reservations.devices, driver: nvidia, count: all, capabilities: [gpu]) と環境変数 ONNX_EXECUTION_PROVIDER=auto を追加 |
| backend/services/depth/estimator.onnx.ts | ONNX_EXECUTION_PROVIDER (auto / cuda / cpu) を導入。auto は CUDA → CPU の順で試行し、セッション作成失敗時は警告ログを出して次の EP にフォールバック |

### 2. 開発者ドキュメントの整備

| ファイル | 変更 |
|---------|------|
| docs/development.md (新) | Compose サービス構成、環境変数、起動/停止、nginx ルーティング、Vite 設定、ホストでのテスト、トラブルシュート、実機テスト手順、GPU 推論の動作確認 |
| docs/structure.md (新) | トップレベル / docker / front / backend の各ディレクトリ役割、_legacy の位置付け、データ配置とライフサイクル、命名規約 |
| docs/issue-6-followups.md (新) | PR #19 マージ後に残った検証項目、未達成の完了条件、PR #19 で明示された将来課題、_legacy の今後、インフラ積み残し、推奨着手順 |
| README.md | 関連ドキュメント節を新ファイル群へ更新 |

## ローカル動作確認

開発機 (RTX 3050 / 6GB VRAM) で 1280x960 ランダム JPEG を送信したときの結果。

| EP | Warm-up (1st) | Hot (2nd〜) |
|----|---------------|-------------|
| CPU | 1.14s | 680〜720ms |
| CUDA | 1.97s | 520〜560ms |

数値は HTTP 往復 + Sharp 前処理 + 深度推論 + 点群生成 + RANSAC + SVG 生成 + Redis 保存を含む合計時間。

その他確認:
- backend 起動ログ: \`[depth] EP=cuda で ONNX セッションを作成しました\`
- \`docker compose exec backend nvidia-smi\` で GPU 認識
- 推論中の VRAM 1.4GB / GPU 利用率 29% (余裕あり)
- \`ONNX_EXECUTION_PROVIDER=cpu\` に切替えても EP=cpu で起動 (CPU フォールバック動作)
- backend テスト 53/53 通過、type-check 通過

## 完了条件 (issue #20)

- [x] backend イメージが CUDA ベースでビルド可能
- [x] コンテナ内で \`nvidia-smi\` が動作
- [x] 起動ログから CUDA EP 選択が分かる
- [x] 推論時間が CPU 比で短縮 (測定値を上記に記載)
- [x] CUDA 不在環境でも CPU フォールバックで起動できる
- [x] 既存テストすべて通過

## 既知の留意点

- iPhone 実機 (Safari) からの一気通貫動作確認は未実施 (バックエンド単体で動作確認のみ)
- nginx / frontend を含めた \`docker compose up -d\` 全体の再起動確認は未実施
- イメージサイズが CUDA ベースで数 GB 増加する。CPU のみで十分な環境では Dockerfile を slim に戻す or 別バリアントを用意する判断もあり

## Test plan

- [ ] \`docker compose build backend\` が成功する
- [ ] \`docker compose up -d\` で全サービスが起動する
- [ ] \`docker compose exec backend nvidia-smi\` で GPU が見える
- [ ] backend ログに \`[depth] EP=cuda で ONNX セッションを作成しました\` が出る
- [ ] iPhone Safari から撮影 → SVG 取得が機能する
- [ ] \`ONNX_EXECUTION_PROVIDER=cpu\` に変更すると EP=cpu で起動する

Generated with [Claude Code](https://claude.com/claude-code)